### PR TITLE
针对Webase-Node-Manager服务初始化启动异常的情形，处理包括alertRule 的NullPointerException…

### DIFF
--- a/src/main/java/com/webank/webase/node/mgr/account/AccountService.java
+++ b/src/main/java/com/webank/webase/node/mgr/account/AccountService.java
@@ -283,8 +283,13 @@ public class AccountService {
                 return ADMIN_TOKEN_VALUE;
             }
         }
-        String token = NodeMgrTools.getToken(request);
-        return tokenService.getValueFromToken(token);
+        try {
+            String token = NodeMgrTools.getToken(request);
+            return tokenService.getValueFromToken(token);
+        } catch (NodeMgrException ex) {
+            log.error("Failed to getCurrentAccount:"+ex);
+            return null;
+        }
     }
 
 }

--- a/src/main/java/com/webank/webase/node/mgr/alert/task/AuditMonitorTask.java
+++ b/src/main/java/com/webank/webase/node/mgr/alert/task/AuditMonitorTask.java
@@ -70,7 +70,7 @@ public class AuditMonitorTask {
         log.info("start checkUserAndContractForAlert startTime:{}", startTime.toEpochMilli());
         //check last alert time, if within interval, not send
         TbAlertRule alertRule = alertRuleService.queryByRuleId(AlertRuleType.AUDIT_ALERT.getValue());
-        if(AlertRuleTools.isWithinAlertIntervalByNow(alertRule)) {
+        if((alertRule==null)||(AlertRuleTools.isWithinAlertIntervalByNow(alertRule))) {
             log.debug("end checkUserAndContractForAlert non-sending mail" +
                     " for beyond alert interval:{}", alertRule);
             return;

--- a/src/main/java/com/webank/webase/node/mgr/alert/task/CertMonitorTask.java
+++ b/src/main/java/com/webank/webase/node/mgr/alert/task/CertMonitorTask.java
@@ -70,7 +70,7 @@ public class CertMonitorTask {
         log.info("start checkCertValidityForAlert startTime:{}", startTime.toEpochMilli());
         //check last alert time, if within interval, not send
         TbAlertRule alertRule = alertRuleService.queryByRuleId(AlertRuleType.CERT_ALERT.getValue());
-        if(AlertRuleTools.isWithinAlertIntervalByNow(alertRule)) {
+        if((alertRule==null)||(AlertRuleTools.isWithinAlertIntervalByNow(alertRule))) {
             log.debug("end checkCertValidityForAlert non-sending mail" +
                     " for beyond alert interval:{}", alertRule);
             return;

--- a/src/main/java/com/webank/webase/node/mgr/alert/task/NodeStatusMonitorTask.java
+++ b/src/main/java/com/webank/webase/node/mgr/alert/task/NodeStatusMonitorTask.java
@@ -73,7 +73,7 @@ public class NodeStatusMonitorTask {
         log.info("start checkAllNodeStatusForAlert startTime:{}", startTime.toEpochMilli());
         //check last alert time, if within interval, not send
         TbAlertRule alertRule = alertRuleService.queryByRuleId(AlertRuleType.NODE_ALERT.getValue());
-        if(AlertRuleTools.isWithinAlertIntervalByNow(alertRule)) {
+        if((alertRule==null)||(AlertRuleTools.isWithinAlertIntervalByNow(alertRule))) {
             log.debug("end checkAllNodeStatusForAlert non-sending mail" +
                     " for beyond alert interval:{}", alertRule);
             return;

--- a/src/main/java/com/webank/webase/node/mgr/base/controller/ErrorController.java
+++ b/src/main/java/com/webank/webase/node/mgr/base/controller/ErrorController.java
@@ -36,6 +36,9 @@ public class ErrorController extends BasicErrorController {
     public ResponseEntity<Map<String, Object>> error(HttpServletRequest request) {
         Map<String, Object> body = getErrorAttributes(request,
             getErrorAttributeOptions(request, MediaType.ALL));
+        if((body==null)||(body.get("message")==null)){
+            throw new NodeMgrException(ConstantCode.SYSTEM_EXCEPTION);
+        }
         String mesage = body.get("message").toString();
         if (StringUtils.isBlank(mesage)) {
             throw new NodeMgrException(ConstantCode.SYSTEM_EXCEPTION);


### PR DESCRIPTION
…和其它一些影响服务正常启动的异常提示信息

例如：
java.lang.NullPointerException: null
        at com.webank.webase.node.mgr.base.controller.ErrorController.error(ErrorController.java:39) ~[WeBASE-Node-Manager-3.0.2.jar:?]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_181]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_181]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_181]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_181]
        at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:205) ~[spring-web-5.3.26.jar:5.3.26]
        at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:150) ~[spring-web-5.3.26.jar:5.3.26]